### PR TITLE
Cleanup of code

### DIFF
--- a/manly.py
+++ b/manly.py
@@ -25,7 +25,10 @@ import subprocess
 import sys
 
 
-# A python3.5 backport to cover differences between 2/3.4 and 3.5
+# A backport from subprocess to cover differences between 2/3.4 and 3.5
+# This allows the same args to be passed into CPE regardless of version.
+# This can be replaced with an import at 2.7 EOL
+# See: https://github.com/carlbordum/manly/issues/27
 class CalledProcessError(subprocess.CalledProcessError):
     def __init__(self, returncode, cmd, output=None, stderr=None):
         self.returncode = returncode
@@ -131,7 +134,7 @@ def manly(command):
                 err,
             )
     except OSError as e:
-        print("Couldn't execute 'man'", file=sys.stderr)
+        print("Could not execute 'man'", file=sys.stderr)
         print(e, file=sys.stderr)
         sys.exit(127)
     except CalledProcessError as e:


### PR DESCRIPTION
the second commit probably needs the most explaining:

* switched from `shell=True` to `shell=False` *(default)*
* Added some basic shims to emulate `subprocess.run` behaviour (throwing an error if the program didn't run correctly)
* Centralized all error handling to `except` statements

when 2020-03 rolls around, ~20 lines of code can be removed

- - -

Due to calling man directly, we no longer need to deal with shell error codes, and we can attribute all error codes to man itself, and display stderr when in such a situation. this fixes #14 